### PR TITLE
fix: Keep only common-configs in main branch

### DIFF
--- a/lua/plugin_config/dap_config/init.lua
+++ b/lua/plugin_config/dap_config/init.lua
@@ -25,6 +25,4 @@ vim.keymap.set('n', 'ev', require 'dapui'.eval)
 -- require('dap').defaults.fallback.switchbuf = 'usetab'
 
 -- configure dap for each language
-require('plugin_config/dap_config/dap_node')
-require('plugin_config/dap_config/dap_go')
-require('plugin_config/dap_config/dap_py')
+-- Eg: require('plugin_config/dap_config/dap_node')

--- a/lua/plugin_config/init.lua
+++ b/lua/plugin_config/init.lua
@@ -4,7 +4,5 @@
 require('plugin_config/dap_config')
 -- coc
 require('plugin_config/coc_config')
--- themes
--- require('plugin_config/themes_config')
 -- telescope
 require('plugin_config/telescope_config')


### PR DESCRIPTION
Addresses #1

- `themes_config` should be part of the `personal` branch
- Language-specific configs in dap should not be in `main` branch.