### PR TITLE
chore: Remove themes_config and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-./lua/plugin_config/dap_config/dap_go.lua
-./lua/plugin_config/dap_config/dap_node.lua
-./lua/plugin_config/dap_config/dap_py.lua

--- a/lua/plugin_config/themes_config.lua
+++ b/lua/plugin_config/themes_config.lua
@@ -1,1 +1,0 @@
-vim.cmd("colorscheme carbonfox")


### PR DESCRIPTION
Addresses #1 

- `themes_config` require was already removed in #3 ; but the file did not get removed
- There is no need of `.gitignore` now that the branch separation strategy is followed.